### PR TITLE
V2.2.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@
 - Fixed the `parameters` block being mandatory on modules with only optional parameters.
 - Fixed items with no variant using the fallback model instead of the vanilla one.
 ## 2.2
+- `custom_data` module now has a `caseInsensitive` option.
 - Parameterized modules no longer need to register a constructor. They may be built directly from their codec instead.
 - Special modules no longer need to register a constructor. They may be registered the same way as Simple modules.
 - Special modules are no longer required to implement their variant logic separately from the special logic.

--- a/Changelog.md
+++ b/Changelog.md
@@ -19,7 +19,7 @@
 - Fixed the `parameters` block being mandatory on modules with only optional parameters.
 - Fixed items with no variant using the fallback model instead of the vanilla one.
 ## 2.2
-- `custom_data` module now has a `caseInsensitive` option.
+- `custom_data` module now has a `caseSensitive` option.
 - Parameterized modules no longer need to register a constructor. They may be built directly from their codec instead.
 - Special modules no longer need to register a constructor. They may be registered the same way as Simple modules.
 - Special modules are no longer required to implement their variant logic separately from the special logic.

--- a/Changelog.md
+++ b/Changelog.md
@@ -18,3 +18,8 @@
 - Added the `custom_name` module
 - Fixed the `parameters` block being mandatory on modules with only optional parameters.
 - Fixed items with no variant using the fallback model instead of the vanilla one.
+## 2.2
+- Parameterized modules no longer need to register a constructor. They may be built directly from their codec instead.
+- Special modules no longer need to register a constructor. They may be registered the same way as Simple modules.
+- Special modules are no longer required to implement their variant logic separately from the special logic.
+- The old ways of registering special and parameterized modules has been marked as deprecated.

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,6 @@ loader_version=0.16.2
 fabric_version=0.102.1+1.21.1
 
 # Mod Properties
-mod_version=2.1.0
+mod_version=2.2.0
 maven_group=fr.estecka.variantscit
 archives_base_name=variants-cit

--- a/src/main/java/fr/estecka/variantscit/ModuleRegistry.java
+++ b/src/main/java/fr/estecka/variantscit/ModuleRegistry.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import com.mojang.serialization.JsonOps;
 import com.mojang.serialization.MapCodec;
 import fr.estecka.variantscit.api.ICitModule;
-import fr.estecka.variantscit.api.ISimpleCitModule;
 import fr.estecka.variantscit.api.ModuleRegistrar.ComplexCitModuleFactory;
 import fr.estecka.variantscit.api.ModuleRegistrar.ParameterizedCitModuleFactory;
 import fr.estecka.variantscit.api.ModuleRegistrar.SpecialCitModuleFactory;
@@ -21,9 +20,10 @@ public final class ModuleRegistry
 
 	static private final Map<Identifier, ManagerFactory> MODULE_TYPES = new HashMap<>();
 
+	@Deprecated
 	static public <T> void Register(Identifier type, ComplexCitModuleFactory<T> moduleFactory, MapCodec<T> codec){
 		assert moduleFactory != null;
-		Register(type, (ModuleDefinition config, JsonObject json) -> {
+		RegisterManager(type, (config, json) -> {
 			var data = codec.decoder().decode(JsonOps.INSTANCE, json);
 			ICitModule module = moduleFactory.Build(config.GetSpecialModelIds(), data.getOrThrow().getFirst());
 			return new VariantManager(config, module);
@@ -32,24 +32,25 @@ public final class ModuleRegistry
 
 	static public <T> void Register(Identifier type, ParameterizedCitModuleFactory<T> moduleFactory, MapCodec<T> codec){
 		assert moduleFactory != null;
-		Register(type, (ModuleDefinition config, JsonObject json) -> {
+		RegisterManager(type, (config, json) -> {
 			var data = codec.decoder().decode(JsonOps.INSTANCE, json);
 			ICitModule module = moduleFactory.Build(data.getOrThrow().getFirst());
 			return new VariantManager(config, module);
 		});
 	}
 
+	@Deprecated
 	static public void Register(Identifier type, SpecialCitModuleFactory moduleFactory){
 		assert moduleFactory != null;
-		Register(type, (config,json)->new VariantManager(config, moduleFactory.Build(config.GetSpecialModelIds())));
+		RegisterManager(type, (config,json)->new VariantManager(config, moduleFactory.Build(config.GetSpecialModelIds())));
 	}
 
-	static public void Register(Identifier type, ISimpleCitModule module){
+	static public void Register(Identifier type, ICitModule module){
 		assert module != null;
-		Register(type, (config,json)->new VariantManager(config, module));
+		RegisterManager(type, (config,json)->new VariantManager(config, module));
 	}
 
-	static private void Register(Identifier type, ManagerFactory factory){
+	static private void RegisterManager(Identifier type, ManagerFactory factory){
 		assert type != null;
 		assert factory != null;
 		if (MODULE_TYPES.containsKey(type))

--- a/src/main/java/fr/estecka/variantscit/ModuleRegistry.java
+++ b/src/main/java/fr/estecka/variantscit/ModuleRegistry.java
@@ -30,11 +30,20 @@ public final class ModuleRegistry
 		});
 	}
 
+	@Deprecated
 	static public <T> void Register(Identifier type, ParameterizedCitModuleFactory<T> moduleFactory, MapCodec<T> codec){
 		assert moduleFactory != null;
 		RegisterManager(type, (config, json) -> {
 			var data = codec.decoder().decode(JsonOps.INSTANCE, json);
 			ICitModule module = moduleFactory.Build(data.getOrThrow().getFirst());
+			return new VariantManager(config, module);
+		});
+	}
+
+	static public void Register(Identifier type, MapCodec<? extends ICitModule> codec){
+		assert codec != null;
+		RegisterManager(type, (config, json) -> {
+			ICitModule module = codec.decoder().decode(JsonOps.INSTANCE, json).getOrThrow().getFirst();
 			return new VariantManager(config, module);
 		});
 	}

--- a/src/main/java/fr/estecka/variantscit/VariantManager.java
+++ b/src/main/java/fr/estecka/variantscit/VariantManager.java
@@ -37,11 +37,7 @@ implements IVariantManager
 	@Deprecated
 	@Override
 	public @Nullable ModelIdentifier GetModelVariantForItem(ItemStack stack){
-		Identifier variant = module.GetItemVariant(stack);
-		if (variant == null)
-			return null;
-
-		return GetVariantModel(variant);
+		return GetVariantModel(module.GetItemVariant(stack));
 	}
 
 	@Override

--- a/src/main/java/fr/estecka/variantscit/VariantManager.java
+++ b/src/main/java/fr/estecka/variantscit/VariantManager.java
@@ -23,29 +23,38 @@ implements IVariantManager
 	/**
 	 * Maps variant IDs to model IDs.
 	 */
-	private Map<Identifier, ModelIdentifier> variantModels = new HashMap<>();
-	private final Set<ModelIdentifier> specialModels = new HashSet<>();
+	private final Map<Identifier, ModelIdentifier> variantModels = new HashMap<>();
+	private final Map<String, ModelIdentifier> specialModels;
 
 
 	public VariantManager(ModuleDefinition definition, ICitModule module){
 		this.module = module;
 		this.prefix = definition.modelPrefix();
 		this.fallbackModel = definition.GetFallbackModelId();
-
-		definition.GetSpecialModelIds().values().stream()
-			.filter(id -> id!=null)
-			.distinct()
-			.forEach(specialModels::add);
-			;
+		this.specialModels = definition.GetSpecialModelIds();
 	}
 
+	@Deprecated
+	@Override
 	public @Nullable ModelIdentifier GetModelVariantForItem(ItemStack stack){
 		Identifier variant = module.GetItemVariant(stack);
 		if (variant == null)
 			return null;
 
-		ModelIdentifier modelId = this.variantModels.get(variant);
-		return (modelId != null) ? modelId : this.fallbackModel;
+		return GetVariantModel(variant);
+	}
+
+	@Override
+	public @Nullable ModelIdentifier GetVariantModel(Identifier variant){
+		if (variant == null)
+			return null;
+		else
+			return this.variantModels.getOrDefault(variant, this.fallbackModel);
+	}
+
+	@Override
+	public @Nullable ModelIdentifier GetSpecialModel(String key){
+		return this.specialModels.get(key);
 	}
 
 	public @Nullable ModelIdentifier GetModelForItem(ItemStack stack){
@@ -60,13 +69,13 @@ implements IVariantManager
 		Set<ModelIdentifier> result = new HashSet<>();
 		result.add(fallbackModel);
 		result.addAll(this.variantModels.values());
-		result.addAll(this.specialModels);
+		result.addAll(this.specialModels.values());
 		result.remove(null);
 		return result;
 	}
 
 	public void ReloadVariants(ResourceManager manager){
-		this.variantModels = new HashMap<>();
+		this.variantModels.clear();
 		
 		String folder = "models";
 		if (prefix.contains("/")){

--- a/src/main/java/fr/estecka/variantscit/VariantsCitMod.java
+++ b/src/main/java/fr/estecka/variantscit/VariantsCitMod.java
@@ -34,7 +34,7 @@ implements ClientModInitializer, PreparableModelLoadingPlugin<Map<Item,VariantMa
 		PreparableModelLoadingPlugin.register(new ModuleLoader(), this);
 
 		ModuleRegistry.Register(Identifier.ofVanilla("axolotl_variant"), new AxolotlBucketModule());
-		ModuleRegistry.Register(Identifier.ofVanilla("custom_data"), CustomVariantModule.CODEC);
+		ModuleRegistry.Register(Identifier.ofVanilla("custom_data"), CustomDataModule.CODEC);
 		ModuleRegistry.Register(Identifier.ofVanilla("custom_name"), CustomNameModule.CODEC);
 		ModuleRegistry.Register(Identifier.ofVanilla("instrument"), new GoatHornModule());
 		ModuleRegistry.Register(Identifier.ofVanilla("jukebox_playable"), new MusicDiscModule());

--- a/src/main/java/fr/estecka/variantscit/VariantsCitMod.java
+++ b/src/main/java/fr/estecka/variantscit/VariantsCitMod.java
@@ -34,8 +34,8 @@ implements ClientModInitializer, PreparableModelLoadingPlugin<Map<Item,VariantMa
 		PreparableModelLoadingPlugin.register(new ModuleLoader(), this);
 
 		ModuleRegistry.Register(Identifier.ofVanilla("axolotl_variant"), new AxolotlBucketModule());
-		ModuleRegistry.Register(Identifier.ofVanilla("custom_data"), CustomVariantModule::new, CustomVariantModule.CODEC);
-		ModuleRegistry.Register(Identifier.ofVanilla("custom_name"), CustomNameModule::new, CustomNameModule.CODEC);
+		ModuleRegistry.Register(Identifier.ofVanilla("custom_data"), CustomVariantModule.CODEC);
+		ModuleRegistry.Register(Identifier.ofVanilla("custom_name"), CustomNameModule.CODEC);
 		ModuleRegistry.Register(Identifier.ofVanilla("instrument"), new GoatHornModule());
 		ModuleRegistry.Register(Identifier.ofVanilla("jukebox_playable"), new MusicDiscModule());
 		ModuleRegistry.Register(Identifier.ofVanilla("potion_effect"), new PotionEffectModule());

--- a/src/main/java/fr/estecka/variantscit/VariantsCitMod.java
+++ b/src/main/java/fr/estecka/variantscit/VariantsCitMod.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import fr.estecka.variantscit.modules.*;
 
 
@@ -41,7 +40,7 @@ implements ClientModInitializer, PreparableModelLoadingPlugin<Map<Item,VariantMa
 		ModuleRegistry.Register(Identifier.ofVanilla("jukebox_playable"), new MusicDiscModule());
 		ModuleRegistry.Register(Identifier.ofVanilla("potion_effect"), new PotionEffectModule());
 		ModuleRegistry.Register(Identifier.ofVanilla("potion_type"), new PotionTypeModule());
-		ModuleRegistry.Register(Identifier.ofVanilla("stored_enchantments"), EnchantedBookModule::new);
+		ModuleRegistry.Register(Identifier.ofVanilla("stored_enchantments"), new EnchantedBookModule());
 
 		ModelPredicateProviderRegistry.register(Items.ENCHANTED_BOOK, Identifier.ofVanilla("level"), new EnchantedBookLevelPredicate());
 		var potionPredicate = new PotionLevelPredicate();

--- a/src/main/java/fr/estecka/variantscit/api/ICitModule.java
+++ b/src/main/java/fr/estecka/variantscit/api/ICitModule.java
@@ -20,7 +20,7 @@ public interface ICitModule
 	 * The main logic for changing an items model.
 	 * 
 	 * @param stack The item stack to evaluate the model for.
-	 * @param variantManager The provider  for both  special  and  variant-based
+	 * @param modelProvider  The provider  for both  special  and  variant-based
 	 * models.
 	 * @return The model ID, or null if the vanilla model should be used.
 	 */

--- a/src/main/java/fr/estecka/variantscit/api/ICitModule.java
+++ b/src/main/java/fr/estecka/variantscit/api/ICitModule.java
@@ -8,24 +8,21 @@ import net.minecraft.util.Identifier;
 public interface ICitModule
 {
 	/**
-	 * Identifies  the item's variant, from which the  model ID will be derived.
-	 * Items with no variants will fallback to the vanilla model.
-	 * 
-	 * @return The variant's identifier, or null if the item has none.
+	 * @deprecated Will  become  exclusive  to {@link ISimpleCitModule}. You may
+	 * now implement that logic directly inside {@link #GetItemModel}.
 	 */
-	public abstract @Nullable Identifier GetItemVariant(ItemStack stack);
+	@Deprecated
+	public default @Nullable Identifier GetItemVariant(ItemStack stack){
+		return null;
+	}
 
 	/**
-	 * Special logic  for overriding the variant-based models  in scenarios that
-	 * are not handled by the mod. E.g: a unique model  for enchanted books with
-	 * more than one enchantement.
-	 * 
-	 * If no  special model  apply to  this item stack,  this should  return the
-	 * value from the {@param variantManager}.
+	 * The main logic for changing an items model.
 	 * 
 	 * @param stack The item stack to evaluate the model for.
-	 * @param variantManager The provider for variant-based models
-	 * @return The model ID , or null if the vanilla model should be used.
+	 * @param variantManager The provider  for both  special  and  variant-based
+	 * models.
+	 * @return The model ID, or null if the vanilla model should be used.
 	 */
-	public abstract @Nullable ModelIdentifier GetItemModel(ItemStack stack, IVariantManager variantManager);
+	public abstract @Nullable ModelIdentifier GetItemModel(ItemStack stack, IVariantManager modelProvider);
 }

--- a/src/main/java/fr/estecka/variantscit/api/ISimpleCitModule.java
+++ b/src/main/java/fr/estecka/variantscit/api/ISimpleCitModule.java
@@ -10,10 +10,16 @@ import net.minecraft.util.Identifier;
 public interface ISimpleCitModule
 extends ICitModule
 {
+	/**
+	 * Identifies  the item's variant, from which the  model ID will be derived.
+	 * Items with no variants will fallback to the vanilla model.
+	 * 
+	 * @return The variant's identifier, or null if the item has none.
+	 */
 	public abstract @Nullable Identifier GetItemVariant(ItemStack stack);
 
 	@Override
-	public default @Nullable ModelIdentifier GetItemModel(ItemStack stack, IVariantManager variantBasedModel){
-		return variantBasedModel.GetModelVariantForItem(stack);
+	public default @Nullable ModelIdentifier GetItemModel(ItemStack stack, IVariantManager modelProvider){
+		return modelProvider.GetVariantModel(GetItemVariant(stack));
 	}
 }

--- a/src/main/java/fr/estecka/variantscit/api/IVariantManager.java
+++ b/src/main/java/fr/estecka/variantscit/api/IVariantManager.java
@@ -1,16 +1,27 @@
 package fr.estecka.variantscit.api;
 
 import org.jetbrains.annotations.Nullable;
-
 import net.minecraft.client.util.ModelIdentifier;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
 
-@FunctionalInterface
 public interface IVariantManager
 {
 	/**
-	 * @return The model that matches this item's variant, (which may be the 
-	 * fallback model), or null if the item has no variant.
+	 * @deprecated  Will be removed alongside {@link ICitModule#GetItemVariant}.
+	 * Use {@link #GetModelForVariant} instead.
 	 */
+	@Deprecated
 	public abstract @Nullable ModelIdentifier GetModelVariantForItem(ItemStack stack);
+
+	/**
+	 * @return The model  that matches  this variant, the  fallback model  if no
+	 * model was provided for this variant, or null if the variant is null.
+	 */
+	public abstract @Nullable ModelIdentifier GetVariantModel(Identifier variantId);
+
+	/**
+	 * @return The special model that was provided for this key.
+	 */
+	public abstract @Nullable ModelIdentifier GetSpecialModel(String key);
 }

--- a/src/main/java/fr/estecka/variantscit/api/IVariantManager.java
+++ b/src/main/java/fr/estecka/variantscit/api/IVariantManager.java
@@ -9,7 +9,7 @@ public interface IVariantManager
 {
 	/**
 	 * @deprecated  Will be removed alongside {@link ICitModule#GetItemVariant}.
-	 * Use {@link #GetModelForVariant} instead.
+	 * Use {@link #GetVariantModel} instead.
 	 */
 	@Deprecated
 	public abstract @Nullable ModelIdentifier GetModelVariantForItem(ItemStack stack);

--- a/src/main/java/fr/estecka/variantscit/api/ModuleRegistrar.java
+++ b/src/main/java/fr/estecka/variantscit/api/ModuleRegistrar.java
@@ -8,19 +8,33 @@ import net.minecraft.util.Identifier;
 
 public final class ModuleRegistrar
 {
+	/**
+	 * @deprecated Modules may now  access the list  of special models  from the
+	 * {@link IVariantManager} provided to {@link ICitModule#GetItemModel}.
+	 */
+	@Deprecated
 	static public interface SpecialCitModuleFactory {
 		ICitModule Build(Map<String, ModelIdentifier> specialModels);
 	}
 
+	@FunctionalInterface
 	static public interface ParameterizedCitModuleFactory<T> {
 		ICitModule Build(T customData);
 	}
 
+	/**
+	 * @deprecated See {@link SpecialCitModuleFactory}
+	 */
+	@Deprecated
 	static public interface ComplexCitModuleFactory<T> {
 		ICitModule Build(Map<String, ModelIdentifier> specialModels, T customData);
 	}
 
 
+	/**
+	 * @deprecated See {@link SpecialCitModuleFactory}
+	 */
+	@Deprecated
 	static public <T> void Register(Identifier moduleId, ComplexCitModuleFactory<T> module, MapCodec<T> customDataCodec){
 		ModuleRegistry.Register(moduleId, module, customDataCodec);
 	}
@@ -29,11 +43,20 @@ public final class ModuleRegistrar
 		ModuleRegistry.Register(moduleId, module, customDataCodec);
 	}
 
+
+	/**
+	 * @deprecated See {@link SpecialCitModuleFactory}
+	 */
+	@Deprecated
 	static public void Register(Identifier moduleId, SpecialCitModuleFactory module){
 		ModuleRegistry.Register(moduleId, module);
 	}
 
 	static public void Register(Identifier moduleId, ISimpleCitModule module){
+		ModuleRegistry.Register(moduleId, module);
+	}
+
+	static public void Register(Identifier moduleId, ICitModule module){
 		ModuleRegistry.Register(moduleId, module);
 	}
 }

--- a/src/main/java/fr/estecka/variantscit/api/ModuleRegistrar.java
+++ b/src/main/java/fr/estecka/variantscit/api/ModuleRegistrar.java
@@ -17,6 +17,9 @@ public final class ModuleRegistrar
 		ICitModule Build(Map<String, ModelIdentifier> specialModels);
 	}
 
+	/**
+	 * @deprecated Modules may now be built directly from their codec.
+	 */
 	@Deprecated
 	static public interface ParameterizedCitModuleFactory<T> {
 		ICitModule Build(T customData);
@@ -39,6 +42,9 @@ public final class ModuleRegistrar
 		ModuleRegistry.Register(moduleId, module, customDataCodec);
 	}
 
+	/**
+	 * @deprecated See {@link ParameterizedCitModuleFactory}
+	 */
 	@Deprecated
 	static public <T> void Register(Identifier moduleId, ParameterizedCitModuleFactory<T> module, MapCodec<T> customDataCodec){
 		ModuleRegistry.Register(moduleId, module, customDataCodec);

--- a/src/main/java/fr/estecka/variantscit/api/ModuleRegistrar.java
+++ b/src/main/java/fr/estecka/variantscit/api/ModuleRegistrar.java
@@ -17,7 +17,7 @@ public final class ModuleRegistrar
 		ICitModule Build(Map<String, ModelIdentifier> specialModels);
 	}
 
-	@FunctionalInterface
+	@Deprecated
 	static public interface ParameterizedCitModuleFactory<T> {
 		ICitModule Build(T customData);
 	}
@@ -39,8 +39,13 @@ public final class ModuleRegistrar
 		ModuleRegistry.Register(moduleId, module, customDataCodec);
 	}
 
+	@Deprecated
 	static public <T> void Register(Identifier moduleId, ParameterizedCitModuleFactory<T> module, MapCodec<T> customDataCodec){
 		ModuleRegistry.Register(moduleId, module, customDataCodec);
+	}
+
+	static public void Register(Identifier moduleId, MapCodec<? extends ICitModule> moduleCodec){
+		ModuleRegistry.Register(moduleId, moduleCodec);
 	}
 
 

--- a/src/main/java/fr/estecka/variantscit/modules/CustomDataModule.java
+++ b/src/main/java/fr/estecka/variantscit/modules/CustomDataModule.java
@@ -11,20 +11,23 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.util.Identifier;
 
-public class CustomVariantModule
+public class CustomDataModule
 implements ISimpleCitModule
 {
-	static public final MapCodec<CustomVariantModule> CODEC = RecordCodecBuilder.mapCodec(builder->builder
+	static public final MapCodec<CustomDataModule> CODEC = RecordCodecBuilder.mapCodec(builder->builder
 		.group(
-			Codec.STRING.fieldOf("nbtKey").forGetter(s->s.key)
+			Codec.STRING.fieldOf("nbtKey").forGetter(s->s.key),
+			Codec.BOOL.fieldOf("caseSensitive").orElse(true).forGetter(s->s.caseSensitive)
 		)
-		.apply(builder, CustomVariantModule::new)
+		.apply(builder, CustomDataModule::new)
 	);
 
 	private final String key;
+	private final boolean caseSensitive;
 
-	public CustomVariantModule(String key){
+	public CustomDataModule(String key, boolean caseSensitive){
 		this.key = key;
+		this.caseSensitive = caseSensitive;
 	}
 
 	@Override
@@ -35,6 +38,10 @@ implements ISimpleCitModule
 		if (component==null || (nbt=component.getNbt())==null || !nbt.contains(key, NbtElement.STRING_TYPE))
 			return null;
 
-		return Identifier.tryParse(nbt.getString(key));
+		String rawVariant = nbt.getString(key);
+		if (!caseSensitive)
+			rawVariant = rawVariant.toLowerCase();
+
+		return Identifier.tryParse(rawVariant);
 	}
 }

--- a/src/main/java/fr/estecka/variantscit/modules/CustomNameModule.java
+++ b/src/main/java/fr/estecka/variantscit/modules/CustomNameModule.java
@@ -14,24 +14,22 @@ import net.minecraft.util.Identifier;
 public class CustomNameModule
 implements ISimpleCitModule
 {
-	static public record CustomNameConfig(boolean caseSensitive, Map<String, Identifier> specialNames) {}
-
-	static public final MapCodec<CustomNameConfig> CODEC = RecordCodecBuilder.mapCodec(builder->builder
+	static public final MapCodec<CustomNameModule> CODEC = RecordCodecBuilder.mapCodec(builder->builder
 		.group(
 			Codec.BOOL.fieldOf("caseSensitive").orElse(false).forGetter(p->p.caseSensitive),
 			Codec.unboundedMap(Codec.STRING, Identifier.CODEC).fieldOf("specialNames").orElse(Map.of()).forGetter(p->p.specialNames)
 		)
-		.apply(builder, CustomNameConfig::new)
+		.apply(builder, CustomNameModule::new)
 	);
 
 	private final boolean caseSensitive;
 	private final Map<String,Identifier> specialNames = new HashMap<>();
 
-	public CustomNameModule(CustomNameConfig params){
-		this.caseSensitive = params.caseSensitive;
+	public CustomNameModule(Boolean caseSensitive, Map<String, Identifier> specialNames){
+		this.caseSensitive = caseSensitive;
 		if (caseSensitive)
-			this.specialNames.putAll(params.specialNames);
-		else for (var e : params.specialNames.entrySet())
+			this.specialNames.putAll(specialNames);
+		else for (var e : specialNames.entrySet())
 			this.specialNames.put(e.getKey().toLowerCase(), e.getValue());
 	}
 

--- a/src/main/java/fr/estecka/variantscit/modules/CustomVariantModule.java
+++ b/src/main/java/fr/estecka/variantscit/modules/CustomVariantModule.java
@@ -14,11 +14,11 @@ import net.minecraft.util.Identifier;
 public class CustomVariantModule
 implements ISimpleCitModule
 {
-	static public final MapCodec<String> CODEC = RecordCodecBuilder.mapCodec(builder->builder
+	static public final MapCodec<CustomVariantModule> CODEC = RecordCodecBuilder.mapCodec(builder->builder
 		.group(
-			Codec.STRING.fieldOf("nbtKey").forGetter(s->s)
+			Codec.STRING.fieldOf("nbtKey").forGetter(s->s.key)
 		)
-		.apply(builder, s->s)
+		.apply(builder, CustomVariantModule::new)
 	);
 
 	private final String key;

--- a/src/main/java/fr/estecka/variantscit/modules/EnchantedBookModule.java
+++ b/src/main/java/fr/estecka/variantscit/modules/EnchantedBookModule.java
@@ -2,37 +2,24 @@ package fr.estecka.variantscit.modules;
 
 import fr.estecka.variantscit.api.ICitModule;
 import fr.estecka.variantscit.api.IVariantManager;
-import java.util.Map;
 import net.minecraft.client.util.ModelIdentifier;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.ItemEnchantmentsComponent;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.Identifier;
 
 public class EnchantedBookModule
 implements ICitModule
 {
-	private final ModelIdentifier citMulti;
-
-	public EnchantedBookModule(Map<String,ModelIdentifier> models){
-		citMulti = models.get("multi");
-	}
-
 	@Override
-	public Identifier GetItemVariant(ItemStack stack){
+	public ModelIdentifier GetItemModel(ItemStack stack, IVariantManager modelProvider){
 		ItemEnchantmentsComponent enchants = stack.get(DataComponentTypes.STORED_ENCHANTMENTS);
-		if (enchants != null && enchants.getSize() == 1)
-			return enchants.getEnchantments().iterator().next().getKey().get().getValue();
-		else
+
+		if (enchants == null || enchants.isEmpty())
 			return null;
-	}
-
-	@Override
-	public ModelIdentifier GetItemModel(ItemStack stack, IVariantManager variant){
-		ItemEnchantmentsComponent enchants = stack.get(DataComponentTypes.STORED_ENCHANTMENTS);
-		if (enchants != null && enchants.getSize() > 1)
-			return citMulti;
+		else if (enchants.getSize() == 1)
+			return modelProvider.GetVariantModel(enchants.getEnchantments().iterator().next().getKey().get().getValue());
 		else
-			return variant.GetModelVariantForItem(stack);
+			return modelProvider.GetSpecialModel("multi");
+
 	}
 }


### PR DESCRIPTION
- `custom_data` module now has a `caseInsensitive` option.
- Parameterized modules no longer need to register a constructor. They may be built directly from their codec instead.
- Special modules no longer need to register a constructor. They may be registered the same way as Simple modules.
- Special modules are no longer required to implement their variant logic separately from the special logic.
- The old ways of registering special and parameterized modules has been marked as deprecated.