### PR TITLE
V2.3.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,3 +24,6 @@
 - Special modules no longer need to register a constructor. They may be registered the same way as Simple modules.
 - Special modules are no longer required to implement their variant logic separately from the special logic.
 - The old ways of registering special and parameterized modules has been marked as deprecated.
+## 2.3
+- It's now possible to apply multiple modules to a single item.
+- It's now possible to apply a single module to multiple items.

--- a/Changelog.md
+++ b/Changelog.md
@@ -29,4 +29,5 @@
 - It's now possible to apply a single module to multiple items.
 - `custom_data` may now look for variants inside nested pathes.
 - `custom_name` will now always convert all names into valid identifiers.
-- `custom_name` 's special names are no longer affected by name transformations.
+- `custom_name`'s case sensitivity option was removed.
+- `custom_name`'s special names are no longer affected by name transformations.

--- a/Changelog.md
+++ b/Changelog.md
@@ -27,7 +27,8 @@
 ## 2.3
 - It's now possible to apply multiple modules to a single item.
 - It's now possible to apply a single module to multiple items.
+- Added the module `enchantment` for tools and armours.
+- `stored_enchantments` (plural) is being renamed to `stored_enchantment` (singular).
 - `custom_data` may now look for variants inside nested pathes.
-- `custom_name` will now always convert all names into valid identifiers.
-- `custom_name`'s case sensitivity option was removed.
-- `custom_name`'s special names are no longer affected by name transformations.
+- `custom_name` will now always convert all names into valid identifiers. The case sensitivity option was removed.
+- `custom_name`'s special names are now case-sensitive.

--- a/Changelog.md
+++ b/Changelog.md
@@ -27,3 +27,6 @@
 ## 2.3
 - It's now possible to apply multiple modules to a single item.
 - It's now possible to apply a single module to multiple items.
+- `custom_data` may now look for variants inside nested pathes.
+- `custom_name` will now always convert all names into valid identifiers.
+- `custom_name` 's special names are no longer affected by name transformations.

--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,6 @@
 - It's now possible to apply a single module to multiple items.
 - Added the module `enchantment` for tools and armours.
 - `stored_enchantments` (plural) is being renamed to `stored_enchantment` (singular).
-- `custom_data` may now look for variants inside nested pathes.
+- `custom_data` may now look for variants inside nested pathes. The parameter `nbtKey` is being renamed to `nbtPath`.
 - `custom_name` will now always convert all names into valid identifiers. The case sensitivity option was removed.
 - `custom_name`'s special names are now case-sensitive.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If Mojang ever makes these items data-driven, you can expect Banner Patterns, Tr
 The base concept for this mod was born out of a need for _optimization_, at a time when CIT-resewn was still an up-to-date option. 
 This comes at the cost of some flexibility; while being _multi_-purpose, it may not be as _all_-purpose as optifine.
 
-This mod excels in scenarios where a single item type has a large amount of variants, which can all be derived from the same piece of data in the item. Instead of defining a condition for every single CIT, you define a single rule that governs all CITs in the same collection (so-called modules).
+This mod excels in scenarios where a single item type has a large amount of variants, which can all be derived from a single piece of data. Instead of defining a condition for every single CIT, you define a single rule that governs all CITs in a collection (so-called modules).
 
 ## Resource Pack Format
 This is an overview, see the [wiki](https://github.com/Estecka/mc-Variants-CIT/wiki) for a complete guide.
@@ -25,7 +25,7 @@ For example, here's a module that would reproduce the behaviour of the previous 
 `/assets/minecraft/variant-cits/item/enchanted_book.json`
 ```json
 {
-	"type": "stored_enchantments",
+	"type": "stored_enchantment",
 	"items": ["enchanted_book"],
 	"modelPrefix": "item/enchanted_book/",
 	"special": {

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ There are also more generic modules that can identify a variant from the `custom
 If Mojang ever makes these items data-driven, you can expect Banner Patterns, Trim Templates, and Pottery Sherds to become supported in the future. 
 
 ## Difference with Optifine/CIT-Resewn
-The base concept for this mod was born out of a need for _optimization_, at a time when optifine was still an up-to-date CIT option. 
-This comes at the cost of some flexibility; while being _multi_-purpose, it may not be as _all_-purpose.
+The base concept for this mod was born out of a need for _optimization_, at a time when CIT-resewn was still an up-to-date option. 
+This comes at the cost of some flexibility; while being _multi_-purpose, it may not be as _all_-purpose as optifine.
 
-The typical scenarios this mod targets are when a single item type has a large amount of variants, and all those variants can be unified under a single all-encompassing rules (so-called modules).
+This mod excels in scenarios where a single item type has a large amount of variants, which can all be derived from the same piece of data in the item. Instead of defining a condition for every single CIT, you define a single rule that governs all CITs in the same collection (so-called modules).
 
 ## Resource Pack Format
 This is an overview, see the [wiki](https://github.com/Estecka/mc-Variants-CIT/wiki) for a complete guide.
 
-The format revolves around item variants (reduced to namespaced identifiers) being automatically associated to [item models](https://minecraft.wiki/w/Model#Item_models) with matching names, stored in a directory of your choosing.
+The format revolves around item **variants** (reduced to namespaced identifiers) being automatically associated to [item models](https://minecraft.wiki/w/Model#Item_models) with matching names, stored in a directory of your choosing.
 
 Resource packs must start by providing a module configuration, that defines what item is affected, how to figure out its variant, and where their models are located.
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ A CIT logic for MC 1.21, optimized around items with standardized variants.
 
 **This mod is not a plug-and-play replacement for Optifine/CIT-resewn;** it uses its own resource format. Changes to older packs are required for them to work.
 
-The mod contains built-in logic for handling **Axolotl Buckets**, **Enchanted Books**, **Music Discs**, **Goat Horns**, and **Potions**. 
-There are also more generic modules that can identify a variant from the `custom_data` or `custom_name` component of an item, other mods can easily create custom logic for their own items.
+The mod contains built-in logic for handling **Axolotl Buckets**, **Enchantments**, **Music Discs**, **Goat Horns**, and **Potions**. 
+There are also more generic modules that can identify a variant from the `custom_data` or `custom_name` component of an item. Other mods can easily create custom logic for their own items.
 
 If Mojang ever makes these items data-driven, you can expect Banner Patterns, Trim Templates, and Pottery Sherds to become supported in the future. 
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,17 @@
 A CIT logic for MC 1.21, optimized around items with standardized variants.
 
 **This mod is not a plug-and-play replacement for Optifine/CIT-resewn;** it uses its own resource format. Changes to older packs are required for them to work.
-On low-end PCs, using this mod instead of the optifine format may lead to improved performances in scenarios where a single item has very many different variants.
 
-The mod is not as all-purpose as optifine, it still requires specialized code for most item type, but this code is modular and easy to expand upon. Other mods can also add custom modules for their own items.
+The mod contains built-in logic for handling **Axolotl Buckets**, **Enchanted Books**, **Music Discs**, **Goat Horns**, and **Potions**. 
+There are also more generic modules that can identify a variant from the `custom_data` or `custom_name` component of an item, other mods can easily create custom logic for their own items.
 
-Built-in modules support **Axolotl Buckets**, **Enchanted Books**, **Music Discs**, **Goat Horns**, and **Potions**.
-There are also more generic modules that can identify a variant from the `custom_data` or `custom_name` component of an item.
-If Mojang ever makes these items more componentized, you can expect Banner Patterns, Trim Templates, and Pottery Sherds to become supported in the future.
+If Mojang ever makes these items data-driven, you can expect Banner Patterns, Trim Templates, and Pottery Sherds to become supported in the future. 
 
+## Difference with Optifine/CIT-Resewn
+The base concept for this mod was born out of a need for _optimization_, at a time when optifine was still an up-to-date CIT option. 
+This comes at the cost of some flexibility; while being _multi_-purpose, it may not be as _all_-purpose.
+
+The typical scenarios this mod targets are when a single item type has a large amount of variants, and all those variants can be unified under a single all-encompassing rules (so-called modules).
 
 ## Resource Pack Format
 The format revolves around item variants (reduced to namespaced identifiers) being automatically associated to [item models](https://minecraft.wiki/w/Model#Item_models) with matching names, stored in a directory of your choosing.

--- a/README.md
+++ b/README.md
@@ -15,23 +15,24 @@ This comes at the cost of some flexibility; while being _multi_-purpose, it may 
 The typical scenarios this mod targets are when a single item type has a large amount of variants, and all those variants can be unified under a single all-encompassing rules (so-called modules).
 
 ## Resource Pack Format
+This is an overview, see the [wiki](https://github.com/Estecka/mc-Variants-CIT/wiki) for a complete guide.
+
 The format revolves around item variants (reduced to namespaced identifiers) being automatically associated to [item models](https://minecraft.wiki/w/Model#Item_models) with matching names, stored in a directory of your choosing.
 
-Resource packs must start by providing a configuration file, that defines what item type is affected, how to figure out its variant, and where the models are located.
+Resource packs must start by providing a module configuration, that defines what item is affected, how to figure out its variant, and where their models are located.
 
 For example, here's a module that would reproduce the behaviour of the previous version of the mod, Enchants-CIT :  
 `/assets/minecraft/variant-cits/item/enchanted_book.json`
 ```json
 {
 	"type": "stored_enchantments",
+	"items": ["enchanted_book"],
 	"modelPrefix": "item/enchanted_book/",
 	"special": {
 		"multi": "enchants-cit:item/multi_enchanted_book"
 	}
 }
 ```
-The targeted item type is automatically derived from the file name of the config.
 Here, the enchantment `minecraft:unbreaking` will be associated with the model stored at `/assets/minecraft/models/item/enchanted_book/unbreaking.json`
 
-Some module types may define additional models to use in special cases, or take addional parameters. 
-See the [wiki](https://github.com/Estecka/mc-Variants-CIT/wiki) for a more complete guide.
+Some module types may define additional models to use in special cases, or take addional parameters.

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,6 @@ loader_version=0.16.2
 fabric_version=0.102.1+1.21.1
 
 # Mod Properties
-mod_version=2.2.0
+mod_version=2.3.0
 maven_group=fr.estecka.variantscit
 archives_base_name=variants-cit

--- a/src/main/java/fr/estecka/variantscit/IItemModelProvider.java
+++ b/src/main/java/fr/estecka/variantscit/IItemModelProvider.java
@@ -1,0 +1,26 @@
+package fr.estecka.variantscit;
+
+import java.util.List;
+import net.minecraft.client.util.ModelIdentifier;
+import net.minecraft.item.ItemStack;
+
+public interface IItemModelProvider
+{
+	ModelIdentifier GetModelForItem(ItemStack stack);
+
+	static public IItemModelProvider OfList(List<? extends IItemModelProvider> providers){
+		if (providers.isEmpty())
+			return __->null;
+		else if (providers.size() == 1)
+			return providers.get(0);
+
+		return (ItemStack stack)->{
+			ModelIdentifier id;
+			for (var p : providers)
+				if (null != (id=p.GetModelForItem(stack)))
+					return id;
+
+			return null;
+		};
+	}
+}

--- a/src/main/java/fr/estecka/variantscit/ModuleDefinition.java
+++ b/src/main/java/fr/estecka/variantscit/ModuleDefinition.java
@@ -1,6 +1,7 @@
 package fr.estecka.variantscit;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.jetbrains.annotations.Nullable;
@@ -13,11 +14,20 @@ import com.mojang.serialization.DataResult;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
-public record ModuleDefinition(Identifier type, String modelPrefix, Optional<Identifier> fallbackModel, Map<String,Identifier> specialModels)
+public record ModuleDefinition(
+	Identifier type,
+	Optional<List<Identifier>> targets,
+	int priority,
+	String modelPrefix,
+	Optional<Identifier> fallbackModel,
+	Map<String,Identifier> specialModels
+)
 {
 	static public final MapCodec<ModuleDefinition> CODEC = RecordCodecBuilder.<ModuleDefinition>mapCodec(builder->builder
 		.group(
 			Identifier.CODEC.fieldOf("type").forGetter(ModuleDefinition::type),
+			Identifier.CODEC.listOf().optionalFieldOf("items").forGetter(ModuleDefinition::targets),
+			Codec.INT.fieldOf("priority").orElse(0).forGetter(ModuleDefinition::priority),
 			Codec.STRING.validate(ModuleDefinition::ValidatePath).fieldOf("modelPrefix").forGetter(ModuleDefinition::modelPrefix),
 			Identifier.CODEC.optionalFieldOf("fallback").forGetter(ModuleDefinition::fallbackModel),
 			Codec.unboundedMap(Codec.STRING, Identifier.CODEC).fieldOf("special").orElse(ImmutableMap.<String,Identifier>of()).forGetter(ModuleDefinition::specialModels)

--- a/src/main/java/fr/estecka/variantscit/ModuleLoader.java
+++ b/src/main/java/fr/estecka/variantscit/ModuleLoader.java
@@ -102,11 +102,6 @@ implements DataLoader<ModuleLoader.Result>
 		return result;
 	}
 
-	/**
-	 * @return An empty optional if the targets were not explicitely defined. An
-	 * empty set  if the targets  are explicitely  set, but  do not  contain any
-	 * valid item ID.
-	 */
 	static private Set<RegistryEntry<Item>> ItemsFromTarget(List<Identifier> targets){
 		Set<RegistryEntry<Item>> result = new HashSet<>();
 		targets.stream()

--- a/src/main/java/fr/estecka/variantscit/ModuleLoader.java
+++ b/src/main/java/fr/estecka/variantscit/ModuleLoader.java
@@ -1,67 +1,135 @@
 package fr.estecka.variantscit;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import org.jetbrains.annotations.Nullable;
 import com.google.gson.JsonObject;
+import com.ibm.icu.impl.Pair;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.JsonOps;
 import net.fabricmc.fabric.api.client.model.loading.v1.PreparableModelLoadingPlugin.DataLoader;
 import net.minecraft.item.Item;
 import net.minecraft.registry.Registries;
+import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.resource.Resource;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.JsonHelper;
 
-public class ModuleLoader
-implements DataLoader<Map<Item,VariantManager>>
+public final class ModuleLoader
+implements DataLoader<ModuleLoader.Result>
 {
+
+	static public class Result {
+		public final Map<RegistryEntry<Item>,List<MetaModule>> modulesPerItem = new HashMap<>();
+	}
+
+	/**
+	 * Contains all the data  pertaining to  a module file. Most of this data is
+	 * only  relevant  to  the  resource-loading  phase, and  will be  discarded
+	 * afterward.
+	 */
+	static public class MetaModule {
+		public final Identifier id;
+		public final VariantManager manager;
+		public final ModuleDefinition definition;
+		public final JsonObject parameters;
+
+		private MetaModule(Identifier id, Resource resource)
+		throws IllegalStateException
+		{
+			this.id = id;
+			var dataResult = DefinitionFromResource(resource);
+			if (dataResult.isError()){
+				throw new IllegalStateException(dataResult.error().get().message());
+			}
+			var pair = dataResult.getOrThrow();
+			this.definition = pair.first;
+			this.parameters = pair.second;
+
+			try {
+				this.manager = ModuleRegistry.CreateManager(this.definition, this.parameters);
+			}
+			catch (IllegalStateException e){
+				throw new IllegalStateException(e);
+			}
+		}
+	}
+
 	@Override
-	public CompletableFuture<Map<Item,VariantManager>> load(ResourceManager resourceManager, Executor executor){
+	public CompletableFuture<ModuleLoader.Result> load(ResourceManager resourceManager, Executor executor){
 		return CompletableFuture.supplyAsync(()->ReloadModules(resourceManager), executor);
 	}
 
-	private Map<Item,VariantManager> ReloadModules(ResourceManager manager){
-		Map<Item,VariantManager> result = new HashMap<>();
+	static private ModuleLoader.Result ReloadModules(ResourceManager manager)
+	{
+		ModuleLoader.Result result = new ModuleLoader.Result();
 
 		for (Map.Entry<Identifier, Resource> entry : manager.findResources("variant-cits/item", id->id.getPath().endsWith(".json")).entrySet())
 		{
 			Identifier resourceId = entry.getKey();
-			Item item = ItemFromResourcePath(resourceId);
-			if (item == null)
-				continue;
-
-			DataResult<VariantManager> dataResult = ManagerFromResource(entry.getValue());
-			if (dataResult.isSuccess()){
-				VariantManager module = dataResult.getOrThrow();
-				module.ReloadVariants(manager);
-				result.put(item, module);
+			MetaModule module;
+			try {
+				module = new MetaModule(entry.getKey(), entry.getValue());
 			}
-			else {
-				VariantsCitMod.LOGGER.error("Error in cit module {}: {}", resourceId, dataResult.error().get().message());
+			catch (IllegalStateException e){
+				VariantsCitMod.LOGGER.error("Error in cit module {}: {}", resourceId, e);
+				continue;
+			}
+
+			module.manager.ReloadVariants(manager);
+
+			Set<RegistryEntry<Item>> targets = module.definition.targets()
+				.map(ModuleLoader::ItemsFromTarget)
+				.orElseGet(()->ItemsFromResourcePath(resourceId))
+				;
+
+			for (var item : targets){
+				result.modulesPerItem.computeIfAbsent(item, __->new ArrayList<>()).add(module);
 			}
 		}
 
+		// Sort highest priorities first.
+		for (List<MetaModule> modules : result.modulesPerItem.values()){
+			modules.sort((a,b) -> -Integer.compare(a.definition.priority(), b.definition.priority()));
+		}
 		return result;
 	}
 
-	static private @Nullable Item ItemFromResourcePath(Identifier resourceId){
+	/**
+	 * @return An empty optional if the targets were not explicitely defined. An
+	 * empty set  if the targets  are explicitely  set, but  do not  contain any
+	 * valid item ID.
+	 */
+	static private Set<RegistryEntry<Item>> ItemsFromTarget(List<Identifier> targets){
+		Set<RegistryEntry<Item>> result = new HashSet<>();
+		targets.stream()
+			.map(id->Registries.ITEM.getEntry(id).get())
+			.filter(o->o!=null)
+			.forEach(result::add)
+			;
+		return result;
+	}
+
+	static private Set<RegistryEntry<Item>> ItemsFromResourcePath(Identifier resourceId){
 		String path = resourceId.getPath();
 		path = path.substring("variant-cits/item".length() + 1, path.length() - ".json".length());
 
 		Identifier itemId = Identifier.of(resourceId.getNamespace(), path);
 
 		if (Registries.ITEM.containsId(itemId))
-			return Registries.ITEM.get(itemId);
+			return Set.of(Registries.ITEM.getEntry(itemId).get());
 		else
-			return null;
+			return Set.of();
 	}
 
-	static private DataResult<VariantManager> ManagerFromResource(Resource resource){
+	static private DataResult<Pair<ModuleDefinition, JsonObject>> DefinitionFromResource(Resource resource){
 		JsonObject json;
 		try {
 			json = JsonHelper.deserialize(resource.getReader());
@@ -81,9 +149,9 @@ implements DataLoader<Map<Item,VariantManager>>
 			if (parameters == null)
 				parameters = new JsonObject();
 
-			return DataResult.success(ModuleRegistry.CreateManager(definition, parameters));
+			return DataResult.success(Pair.of(definition, parameters));
 		}
-		catch (IllegalArgumentException|IllegalStateException|ClassCastException e){
+		catch (IllegalStateException|ClassCastException e){
 			return DataResult.error(e::toString);
 		}
 	}

--- a/src/main/java/fr/estecka/variantscit/ModuleRegistry.java
+++ b/src/main/java/fr/estecka/variantscit/ModuleRegistry.java
@@ -69,13 +69,13 @@ public final class ModuleRegistry
 	}
 
 	static public VariantManager CreateManager(ModuleDefinition definition, JsonObject customData)
-	throws IllegalArgumentException, IllegalStateException
+	throws IllegalStateException
 	{
 		assert definition != null;
 		Identifier type = definition.type();
 
 		if (!MODULE_TYPES.containsKey(type))
-			throw new IllegalArgumentException("Unknown module type: " + type.toString());
+			throw new IllegalStateException("Unknown module type: " + type.toString());
 
 		return MODULE_TYPES.get(type).build(definition, customData);
 	}

--- a/src/main/java/fr/estecka/variantscit/VariantManager.java
+++ b/src/main/java/fr/estecka/variantscit/VariantManager.java
@@ -41,6 +41,11 @@ implements IVariantManager, IItemModelProvider
 	}
 
 	@Override
+	public boolean HasVariantModel(Identifier variant){
+		return this.variantModels.containsKey(variant);
+	}
+
+	@Override
 	public @Nullable ModelIdentifier GetVariantModel(Identifier variant){
 		if (variant == null)
 			return null;

--- a/src/main/java/fr/estecka/variantscit/VariantManager.java
+++ b/src/main/java/fr/estecka/variantscit/VariantManager.java
@@ -14,7 +14,7 @@ import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
 
 public final class VariantManager
-implements IVariantManager
+implements IVariantManager, IItemModelProvider
 {
 	private final ICitModule module;
 	private final String prefix;

--- a/src/main/java/fr/estecka/variantscit/VariantsCitMod.java
+++ b/src/main/java/fr/estecka/variantscit/VariantsCitMod.java
@@ -43,7 +43,11 @@ implements ClientModInitializer, PreparableModelLoadingPlugin<ModuleLoader.Resul
 		ModuleRegistry.Register(Identifier.ofVanilla("jukebox_playable"), new MusicDiscModule());
 		ModuleRegistry.Register(Identifier.ofVanilla("potion_effect"), new PotionEffectModule());
 		ModuleRegistry.Register(Identifier.ofVanilla("potion_type"), new PotionTypeModule());
-		ModuleRegistry.Register(Identifier.ofVanilla("stored_enchantments"), new EnchantedBookModule());
+		ModuleRegistry.Register(Identifier.ofVanilla("stored_enchantment"), new EnchantedBookModule());
+		ModuleRegistry.Register(Identifier.ofVanilla("stored_enchantments"), _0 -> {
+			LOGGER.warn("Module name `stored_enchantments` (plural) is being deprecated. use `stored_enchantment` (singular) instead.");
+			return new EnchantedBookModule();
+		});
 
 		ModelPredicateProviderRegistry.register(Items.ENCHANTED_BOOK, Identifier.ofVanilla("level"), new EnchantedBookLevelPredicate());
 		var potionPredicate = new PotionLevelPredicate();

--- a/src/main/java/fr/estecka/variantscit/VariantsCitMod.java
+++ b/src/main/java/fr/estecka/variantscit/VariantsCitMod.java
@@ -38,6 +38,7 @@ implements ClientModInitializer, PreparableModelLoadingPlugin<ModuleLoader.Resul
 		ModuleRegistry.Register(Identifier.ofVanilla("axolotl_variant"), new AxolotlBucketModule());
 		ModuleRegistry.Register(Identifier.ofVanilla("custom_data"), CustomDataModule.CODEC);
 		ModuleRegistry.Register(Identifier.ofVanilla("custom_name"), CustomNameModule.CODEC);
+		ModuleRegistry.Register(Identifier.ofVanilla("enchantment"), new EnchantedToolModule());
 		ModuleRegistry.Register(Identifier.ofVanilla("instrument"), new GoatHornModule());
 		ModuleRegistry.Register(Identifier.ofVanilla("jukebox_playable"), new MusicDiscModule());
 		ModuleRegistry.Register(Identifier.ofVanilla("potion_effect"), new PotionEffectModule());

--- a/src/main/java/fr/estecka/variantscit/VariantsCitMod.java
+++ b/src/main/java/fr/estecka/variantscit/VariantsCitMod.java
@@ -7,25 +7,27 @@ import net.minecraft.client.item.ModelPredicateProviderRegistry;
 import net.minecraft.client.util.ModelIdentifier;
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;
-import net.minecraft.registry.Registries;
 import net.minecraft.util.Identifier;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import fr.estecka.variantscit.ModuleLoader.MetaModule;
 import fr.estecka.variantscit.modules.*;
 
 
 public class VariantsCitMod
-implements ClientModInitializer, PreparableModelLoadingPlugin<Map<Item,VariantManager>>
+implements ClientModInitializer, PreparableModelLoadingPlugin<ModuleLoader.Result>
 {
 	static public final String MODID = "variants-cit";
 	public static final Logger LOGGER = LoggerFactory.getLogger(MODID);
 
-	static private Map<Item, VariantManager> MODULES = new HashMap<>();
+	static private Map<Item, IItemModelProvider> MODULES = new HashMap<>();
 
-	static public @Nullable VariantManager GetModule(Item itemType){
+	static public @Nullable IItemModelProvider GetModule(Item itemType){
 		return MODULES.get(itemType);
 	}
 
@@ -50,15 +52,23 @@ implements ClientModInitializer, PreparableModelLoadingPlugin<Map<Item,VariantMa
 	}
 
 	@Override
-	public void onInitializeModelLoader(Map<Item,VariantManager> modules, ModelLoadingPlugin.Context pluginContext){
-		MODULES = modules;
-		for (var entry : MODULES.entrySet()){
-			VariantManager module = entry.getValue();
-			Identifier itemId = Registries.ITEM.getId(entry.getKey());
+	public void onInitializeModelLoader(ModuleLoader.Result result, ModelLoadingPlugin.Context pluginContext){
+		Set<MetaModule> uniqueModules = new HashSet<>();
 
-			module.GetAllModels().stream().map(ModelIdentifier::id).forEach(pluginContext::addModels);
-			LOGGER.info("Loaded {} CITs for item {}", module.GetVariantCount(), itemId);
+		MODULES = new HashMap<>();
+		for (var entry : result.modulesPerItem.entrySet()){
+			uniqueModules.addAll(entry.getValue());
+			MODULES.put(
+				entry.getKey().value(),
+				IItemModelProvider.OfList( entry.getValue().stream().map(meta->meta.manager).toList() )
+			);
 		}
+
+		for (MetaModule module : uniqueModules){
+			module.manager.GetAllModels().stream().map(ModelIdentifier::id).forEach(pluginContext::addModels);
+			LOGGER.info("Found {} variants for CIT module {}", module.manager.GetVariantCount(), module.id);
+		}
+
 	}
 
 }

--- a/src/main/java/fr/estecka/variantscit/api/IVariantManager.java
+++ b/src/main/java/fr/estecka/variantscit/api/IVariantManager.java
@@ -15,6 +15,12 @@ public interface IVariantManager
 	public abstract @Nullable ModelIdentifier GetModelVariantForItem(ItemStack stack);
 
 	/**
+	 * @return  Whether this variant  has it's own model, ignoring  the fallback
+	 * model.
+	 */
+	public abstract boolean HasVariantModel(Identifier variantId);
+
+	/**
 	 * @return The model  that matches  this variant, the  fallback model  if no
 	 * model was provided for this variant, or null if the variant is null.
 	 */

--- a/src/main/java/fr/estecka/variantscit/mixin/ItemRendererMixin.java
+++ b/src/main/java/fr/estecka/variantscit/mixin/ItemRendererMixin.java
@@ -12,7 +12,7 @@ import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.render.model.BakedModelManager;
 import net.minecraft.client.util.ModelIdentifier;
 import net.minecraft.item.ItemStack;
-import fr.estecka.variantscit.VariantManager;
+import fr.estecka.variantscit.IItemModelProvider;
 import fr.estecka.variantscit.VariantsCitMod;
 
 @Mixin(ItemRenderer.class)
@@ -22,7 +22,7 @@ public class ItemRendererMixin
 	@WrapOperation( method="getModel", at=@At( value="INVOKE", target="net/minecraft/client/render/item/ItemModels.getModel (Lnet/minecraft/item/ItemStack;)Lnet/minecraft/client/render/model/BakedModel;") )
 	private BakedModel	GetVariantModel(ItemModels models, ItemStack stack, Operation<BakedModel> original)
 	{
-		final VariantManager module = VariantsCitMod.GetModule(stack.getItem());
+		final IItemModelProvider module = VariantsCitMod.GetModule(stack.getItem());
 		ModelIdentifier modelId;
 
 		if (module == null || (modelId=module.GetModelForItem(stack)) == null)

--- a/src/main/java/fr/estecka/variantscit/modules/CustomDataModule.java
+++ b/src/main/java/fr/estecka/variantscit/modules/CustomDataModule.java
@@ -1,5 +1,6 @@
 package fr.estecka.variantscit.modules;
 
+import java.util.Optional;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
@@ -9,6 +10,7 @@ import net.minecraft.component.type.NbtComponent;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtString;
 import net.minecraft.util.Identifier;
 
 public class CustomDataModule
@@ -16,32 +18,63 @@ implements ISimpleCitModule
 {
 	static public final MapCodec<CustomDataModule> CODEC = RecordCodecBuilder.mapCodec(builder->builder
 		.group(
-			Codec.STRING.fieldOf("nbtKey").forGetter(s->s.key),
+			Codec.STRING.optionalFieldOf("nbtKey").forGetter(s->Optional.empty()),
+			Codec.STRING.optionalFieldOf("nbtPath").forGetter(s->Optional.empty()),
 			Codec.BOOL.fieldOf("caseSensitive").orElse(true).forGetter(s->s.caseSensitive)
 		)
 		.apply(builder, CustomDataModule::new)
 	);
 
-	private final String key;
+	/**
+	 * TODO: implement proper getter for the codec.
+	 */
+	private final String[] path;
 	private final boolean caseSensitive;
 
-	public CustomDataModule(String key, boolean caseSensitive){
-		this.key = key;
+	private CustomDataModule(Optional<String> key, Optional<String> path, boolean caseSensitive)
+	throws IllegalStateException
+	{
 		this.caseSensitive = caseSensitive;
+		if (path.isPresent())
+			this.path = ParsePath(path.get());
+		else if (key.isPresent())
+			this.path = new String[]{ key.get() };
+		else
+			throw new IllegalStateException("Nbt path not set");
 	}
 
 	@Override
 	public Identifier GetItemVariant(ItemStack stack){
 		NbtComponent component = stack.get(DataComponentTypes.CUSTOM_DATA);
-		NbtCompound nbt;
-
-		if (component==null || (nbt=component.getNbt())==null || !nbt.contains(key, NbtElement.STRING_TYPE))
+		NbtElement nbt;
+		if (component==null || (nbt=component.getNbt())==null)
 			return null;
 
-		String rawVariant = nbt.getString(key);
+		for (int i=0; i<path.length; ++i)
+		if  (nbt instanceof NbtCompound compound)
+			nbt = compound.get(path[i]);
+		else
+			return null;
+
+		if (!(nbt instanceof NbtString))
+			return null;
+
+		String rawVariant = nbt.asString();
 		if (!caseSensitive)
 			rawVariant = rawVariant.toLowerCase();
 
 		return Identifier.tryParse(rawVariant);
+	}
+
+	static private String[] ParsePath(String rawPath)
+	throws IllegalStateException
+	{
+		String[] result = rawPath.split("\\.");
+
+		for (String s : result)
+			if (s.isEmpty())
+				throw new IllegalStateException("Malformatted path: "+rawPath);
+
+		return result;
 	}
 }

--- a/src/main/java/fr/estecka/variantscit/modules/CustomDataModule.java
+++ b/src/main/java/fr/estecka/variantscit/modules/CustomDataModule.java
@@ -2,8 +2,10 @@ package fr.estecka.variantscit.modules;
 
 import java.util.Optional;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import fr.estecka.variantscit.VariantsCitMod;
 import fr.estecka.variantscit.api.ISimpleCitModule;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.NbtComponent;
@@ -18,7 +20,10 @@ implements ISimpleCitModule
 {
 	static public final MapCodec<CustomDataModule> CODEC = RecordCodecBuilder.mapCodec(builder->builder
 		.group(
-			Codec.STRING.optionalFieldOf("nbtKey").deprecated(0).forGetter(s->Optional.empty()),
+			Codec.STRING.optionalFieldOf("nbtKey").deprecated(0).validate(_0 -> {
+				VariantsCitMod.LOGGER.warn("The custom_data parameter `nbtKey` is being deprecated. Use `nbtPath` instead.");
+				return DataResult.success(_0);
+			}).forGetter(s->Optional.empty()),
 			Codec.STRING.optionalFieldOf("nbtPath").forGetter(s->Optional.empty()),
 			Codec.BOOL.fieldOf("caseSensitive").orElse(true).forGetter(s->s.caseSensitive)
 		)

--- a/src/main/java/fr/estecka/variantscit/modules/CustomDataModule.java
+++ b/src/main/java/fr/estecka/variantscit/modules/CustomDataModule.java
@@ -18,7 +18,7 @@ implements ISimpleCitModule
 {
 	static public final MapCodec<CustomDataModule> CODEC = RecordCodecBuilder.mapCodec(builder->builder
 		.group(
-			Codec.STRING.optionalFieldOf("nbtKey").forGetter(s->Optional.empty()),
+			Codec.STRING.optionalFieldOf("nbtKey").deprecated(0).forGetter(s->Optional.empty()),
 			Codec.STRING.optionalFieldOf("nbtPath").forGetter(s->Optional.empty()),
 			Codec.BOOL.fieldOf("caseSensitive").orElse(true).forGetter(s->s.caseSensitive)
 		)

--- a/src/main/java/fr/estecka/variantscit/modules/CustomNameModule.java
+++ b/src/main/java/fr/estecka/variantscit/modules/CustomNameModule.java
@@ -42,10 +42,8 @@ implements ISimpleCitModule
 		this.caseSensitive = caseSensitive;
 		this.keepIllegal = keepIllegal;
 
-		if (caseSensitive)
-			this.specialNames.putAll(specialNames);
-		else for (var e : specialNames.entrySet())
-			this.specialNames.put(e.getKey().toLowerCase(), e.getValue());
+		for (var e : specialNames.entrySet())
+			this.specialNames.put(this.Transform(e.getKey().toLowerCase()), e.getValue());
 	}
 
 	@Override
@@ -58,22 +56,24 @@ implements ISimpleCitModule
 	}
 
 	public Identifier GetVariantFromText(Text text){
-		String name = text.getString();
+		String name = this.Transform(text.getString());
+		VariantsCitMod.LOGGER.warn("Cached {}: {} -> {}", cachedVariants.size(), text.getString(), name);
 
-		if (!caseSensitive)
+		if (specialNames.containsKey(name))
+			return specialNames.get(name);
+		else
+			return Identifier.tryParse(name);
+	}
+
+	public String Transform(String name){
+		if (!this.caseSensitive)
 			name = name.toLowerCase();
 
-		if (specialNames.containsKey(name)){
-			VariantsCitMod.LOGGER.warn("Cached {}: {} -> {}", cachedVariants.size(), text.getString(), name);
-			return specialNames.get(name);
-		}
-
-		if (!keepIllegal){
+		if (!this.keepIllegal){
 			name = name.replace(' ', '_');
-			name.replaceAll("[^a-zA-Z0-9_.-]", "");
+			name.replaceAll("^[a-zA-Z0-9_.-]", "");
 		}
 
-		VariantsCitMod.LOGGER.warn("Cached {}: {} -> {}", cachedVariants.size(), text.getString(), name);
-		return Identifier.tryParse(name);
+		return name;
 	}
 }

--- a/src/main/java/fr/estecka/variantscit/modules/CustomNameModule.java
+++ b/src/main/java/fr/estecka/variantscit/modules/CustomNameModule.java
@@ -2,9 +2,11 @@ package fr.estecka.variantscit.modules;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.WeakHashMap;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import fr.estecka.variantscit.VariantsCitMod;
 import fr.estecka.variantscit.api.ISimpleCitModule;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.item.ItemStack;
@@ -22,8 +24,15 @@ implements ISimpleCitModule
 		.apply(builder, CustomNameModule::new)
 	);
 
+	private final WeakHashMap<Text, Identifier> cachedVariants = new WeakHashMap<>();
+
 	private final boolean caseSensitive;
 	private final Map<String,Identifier> specialNames = new HashMap<>();
+	private final Map<Character,Character> illegalConversions = new HashMap<>();
+	{
+		illegalConversions.put(' ', '_');
+		illegalConversions.put('\'', '-');
+	}
 
 	public CustomNameModule(Boolean caseSensitive, Map<String, Identifier> specialNames){
 		this.caseSensitive = caseSensitive;
@@ -39,11 +48,24 @@ implements ISimpleCitModule
 		if (component == null)
 			return null;
 
-		String name = component.getString();
+		return cachedVariants.computeIfAbsent(component, this::GetVariantFromText);
+	}
+
+	public Identifier GetVariantFromText(Text text){
+		String name = text.getString();
+
 		if (!caseSensitive)
 			name = name.toLowerCase();
 
-		Identifier variant = specialNames.get(name);
-		return (variant != null) ? variant : Identifier.tryParse(name);
+		if (specialNames.containsKey(name)){
+			VariantsCitMod.LOGGER.warn("Cached {}: {} -> {}", cachedVariants.size(), text.getString(), name);
+			return specialNames.get(name);
+		}
+
+		for (var e : illegalConversions.entrySet())
+			name = name.replace(e.getKey(), e.getValue());
+
+		VariantsCitMod.LOGGER.warn("Cached {}: {} -> {}", cachedVariants.size(), text.getString(), name);
+		return Identifier.tryParse(name);
 	}
 }

--- a/src/main/java/fr/estecka/variantscit/modules/CustomNameModule.java
+++ b/src/main/java/fr/estecka/variantscit/modules/CustomNameModule.java
@@ -3,6 +3,7 @@ package fr.estecka.variantscit.modules;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.WeakHashMap;
+import org.jetbrains.annotations.Nullable;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
@@ -32,7 +33,7 @@ implements ISimpleCitModule
 	 * Keys  are  evaluated  by identity, not  by content. Item  components  are
 	 * supposed to be immutable, so the value of text should change.
 	 */
-	private final WeakHashMap<Text, Identifier> cachedVariants = new WeakHashMap<>();
+	private final WeakHashMap<Text, @Nullable Identifier> cachedVariants = new WeakHashMap<>();
 
 	private final boolean caseSensitive;
 	private final boolean keepIllegal;
@@ -52,7 +53,10 @@ implements ISimpleCitModule
 		if (component == null)
 			return null;
 
-		return cachedVariants.computeIfAbsent(component, this::GetVariantFromText);
+		if (!cachedVariants.containsKey(component))
+			cachedVariants.put(component, GetVariantFromText(component));
+		return cachedVariants.get(component);
+
 	}
 
 	public Identifier GetVariantFromText(Text text){
@@ -71,7 +75,7 @@ implements ISimpleCitModule
 
 		if (!this.keepIllegal){
 			name = name.replace(' ', '_');
-			name.replaceAll("^[a-zA-Z0-9_.-]", "");
+			name = name.replaceAll("[^a-zA-Z0-9_.-]", "");
 		}
 
 		return name;

--- a/src/main/java/fr/estecka/variantscit/modules/CustomNameModule.java
+++ b/src/main/java/fr/estecka/variantscit/modules/CustomNameModule.java
@@ -1,5 +1,6 @@
 package fr.estecka.variantscit.modules;
 
+import java.text.Normalizer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -61,7 +62,7 @@ implements ISimpleCitModule
 
 	public Identifier GetVariantFromText(Text text){
 		String name = this.Transform(text.getString());
-		VariantsCitMod.LOGGER.warn("Cached {}: {} -> {}", cachedVariants.size(), text.getString(), name);
+		// VariantsCitMod.LOGGER.warn("Cached {}: {} -> {}", cachedVariants.size(), text.getString(), name);
 
 		if (specialNames.containsKey(name))
 			return specialNames.get(name);
@@ -75,6 +76,7 @@ implements ISimpleCitModule
 
 		if (!this.keepIllegal){
 			name = name.replace(' ', '_');
+			name = Normalizer.normalize(name, Normalizer.Form.NFD);
 			name = name.replaceAll("[^a-zA-Z0-9_.-]", "");
 		}
 

--- a/src/main/java/fr/estecka/variantscit/modules/EnchantedToolModule.java
+++ b/src/main/java/fr/estecka/variantscit/modules/EnchantedToolModule.java
@@ -1,0 +1,45 @@
+package fr.estecka.variantscit.modules;
+
+import java.util.Iterator;
+import fr.estecka.variantscit.api.ISimpleCitModule;
+import it.unimi.dsi.fastutil.objects.Object2IntMap.Entry;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.ItemEnchantmentsComponent;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.util.Identifier;
+
+public class EnchantedToolModule
+implements ISimpleCitModule
+{
+	@Override
+	public Identifier GetItemVariant(ItemStack stack){
+		ItemEnchantmentsComponent enchants = stack.get(DataComponentTypes.ENCHANTMENTS);
+
+		if (enchants == null || enchants.isEmpty())
+			return null;
+
+		Iterator<Entry<RegistryEntry<Enchantment>>> iterator = enchants.getEnchantmentEntries().iterator();
+		var bestFit = iterator.next();
+		while (iterator.hasNext()){
+			var contestant = iterator.next();
+			if (Compare(contestant, bestFit) > 0)
+				bestFit = contestant;
+		}
+
+		return bestFit.getKey().getKey().get().getValue();
+	}
+
+	public int Compare(Entry<RegistryEntry<Enchantment>> a, Entry<RegistryEntry<Enchantment>> b){
+		int result = 0;
+
+		result = a.getKey().value().exclusiveSet().size() - b.getKey().value().exclusiveSet().size();
+		if (result != 0) return result;
+
+		result = a.getIntValue() - b.getIntValue();
+		if (result != 0) return result;
+
+		return result;
+	}
+}

--- a/src/main/java/fr/estecka/variantscit/modules/EnchantedToolModule.java
+++ b/src/main/java/fr/estecka/variantscit/modules/EnchantedToolModule.java
@@ -1,22 +1,22 @@
 package fr.estecka.variantscit.modules;
 
 import java.util.Iterator;
-import fr.estecka.variantscit.api.ISimpleCitModule;
+import fr.estecka.variantscit.api.ICitModule;
+import fr.estecka.variantscit.api.IVariantManager;
 import it.unimi.dsi.fastutil.objects.Object2IntMap.Entry;
+import net.minecraft.client.util.ModelIdentifier;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.ItemEnchantmentsComponent;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.entry.RegistryEntry;
-import net.minecraft.util.Identifier;
 
 public class EnchantedToolModule
-implements ISimpleCitModule
+implements ICitModule
 {
 	@Override
-	public Identifier GetItemVariant(ItemStack stack){
+	public ModelIdentifier GetItemModel(ItemStack stack, IVariantManager models){
 		ItemEnchantmentsComponent enchants = stack.get(DataComponentTypes.ENCHANTMENTS);
-
 		if (enchants == null || enchants.isEmpty())
 			return null;
 
@@ -24,15 +24,21 @@ implements ISimpleCitModule
 		var bestFit = iterator.next();
 		while (iterator.hasNext()){
 			var contestant = iterator.next();
-			if (Compare(contestant, bestFit) > 0)
+			if (Compare(contestant, bestFit, models) > 0)
 				bestFit = contestant;
 		}
 
-		return bestFit.getKey().getKey().get().getValue();
+		return models.GetVariantModel(bestFit.getKey().getKey().get().getValue());
 	}
 
-	public int Compare(Entry<RegistryEntry<Enchantment>> a, Entry<RegistryEntry<Enchantment>> b){
+	public int Compare(Entry<RegistryEntry<Enchantment>> a, Entry<RegistryEntry<Enchantment>> b, IVariantManager models){
 		int result = 0;
+
+		result = Boolean.compare(
+			models.HasVariantModel(a.getKey().getKey().get().getValue()),
+			models.HasVariantModel(b.getKey().getKey().get().getValue())
+		);
+		if (result != 0) return result;
 
 		result = a.getKey().value().exclusiveSet().size() - b.getKey().value().exclusiveSet().size();
 		if (result != 0) return result;


### PR DESCRIPTION
- It's now possible to apply a single module to multiple items.
- It's now possible to apply multiple modules to a single item, (acting as fallback for each other).
- Added the module `enchantment` for tools and armours.
- `stored_enchantments` (plural) is being renamed to `stored_enchantment` (singular).
- `custom_data` may now look for variants inside nested pathes.
- `custom_name` will now always convert all names into valid identifiers. The case sensitivity option was removed.
- `custom_name`'s special names are now case-sensitive.